### PR TITLE
Get projects and owners from org level down

### DIFF
--- a/gcp_get_proj-ids-get-owner.sh
+++ b/gcp_get_proj-ids-get-owner.sh
@@ -63,6 +63,12 @@ while true; do
 
       printf "Organization: ${ORGANIZATION}\n\n"
       PARSEOPT="organization=${ORGANIZATION}"
+
+      LINES=$(gcloud resource-manager folders list \
+        --"${PARSEOPT}" \
+        --format="${FORMAT}")
+
+      folders ${LINES[0]}
       break;;
     FLD)
       read -p "Enter Folder ID #: " folderID


### PR DESCRIPTION
Hi, 

I came across this collection of scripts from StackOverflow (https://stackoverflow.com/a/65401571), and it's saved me a heap of time so thank you!

I couldn't get the Org parse of the `gcp_get_proj-ids-get-owner.sh` script to output anything until I copy/pasted this chunk from the `FLD` section

Thanks again 🙌


